### PR TITLE
Add `readonly` modifier to separatorKeysCodes

### DIFF
--- a/src/material-examples/chips-input/chips-input-example.ts
+++ b/src/material-examples/chips-input/chips-input-example.ts
@@ -17,7 +17,7 @@ export class ChipsInputExample {
   addOnBlur: boolean = true;
 
   // Enter, comma
-  separatorKeysCodes = [ENTER, COMMA];
+  readonly separatorKeysCodes = [ENTER, COMMA];
 
   fruits = [
     { name: 'Lemon' },


### PR DESCRIPTION
Since separatorKeysCodes isn't changed after initialization, it would be better if it was explicitly marked as readonly.